### PR TITLE
Implement precision at 10

### DIFF
--- a/model_evaluation/metrics.py
+++ b/model_evaluation/metrics.py
@@ -1,0 +1,31 @@
+import numpy as np
+import warnings
+
+
+def average_precision(recipients_prediction, true_recipients):
+    """ Compute average precision@10 between 2 lists (one recipients prediction for one message) """
+    precision = 0.0
+    true_recipients_in_predictions = 0
+
+    for prediction_rank, prediction in enumerate(recipients_prediction):
+        if prediction in true_recipients and prediction not in recipients_prediction[:prediction_rank]:
+            true_recipients_in_predictions += 1
+            precision += true_recipients_in_predictions / (prediction_rank + 1)
+
+    return round(precision / min(len(true_recipients), 10), 5)
+
+
+def mean_average_precision(recipients_predictions, true_recipients_list):
+    """ Compute *mean* average precision@10 between 2 lists of lists (all recipients prediction for all messages) """
+
+    if all(isinstance(recipients_prediction, list) for recipients_prediction in recipients_predictions):
+        each_prediction_average_precision = list()
+
+        for recipients_prediction, true_recipients in zip(recipients_predictions, true_recipients_list):
+            each_prediction_average_precision.append(average_precision(recipients_prediction, true_recipients))
+
+        return np.mean(each_prediction_average_precision)
+
+    else:
+        warnings.warn("Use average precision to compute an average precision@10 between two lists", UserWarning)
+        return average_precision(recipients_predictions, true_recipients_list)

--- a/model_evaluation/test_metrics.py
+++ b/model_evaluation/test_metrics.py
@@ -1,0 +1,180 @@
+import unittest
+from . import metrics
+import warnings
+
+
+class TestAveragePrecisionAt10(unittest.TestCase):
+
+    def setUp(self):
+        self.recipients_prediction = [
+            'jack@enron.com',
+            'ben@enron.com',
+            'maria@enron.com',
+            'peter@enron.com',
+            'christian@enron.com',
+            'marc@enron.com',
+            'hugues@enron.com',
+            'nathan@enron.com',
+            'robin@enron.com',
+            'sophie@enron.com',
+        ]
+
+    def assertAveragePrecisionEquals(self, true_recipients, p):
+        self.assertEqual(
+            metrics.average_precision(
+                recipients_prediction=self.recipients_prediction,
+                true_recipients=true_recipients
+            ), p
+        )
+
+    def test_avg_precision_score_one_length_one(self):
+        true_recipients = ['jack@enron.com']
+        self.assertAveragePrecisionEquals(true_recipients, 1)
+
+    def test_avg_precision_score_zero_length_one(self):
+        true_recipients = ['michelle@enron.com']
+        self.assertAveragePrecisionEquals(true_recipients, 0)
+
+    def test_avg_precision_score_order_matters(self):
+        true_recipients = ['ben@enron.com']
+        self.assertAveragePrecisionEquals(true_recipients, 0.5)
+
+    def test_avg_precision_score_order_matters_length_two(self):
+        true_recipients = ['ben@enron.com', 'michelle@enron.com']
+        self.assertAveragePrecisionEquals(true_recipients, 0.25)
+
+    def test_avg_precision_complex_score_length_ten(self):
+        true_recipients = [
+            'ben@enron.com',         # 1: In predictions
+            'michelle@enron.com',    # 2: Not in predictions
+            'jack@enron.com',        # 3: In predictions
+            'sophie@enron.com',      # 4: Not in predictions
+            'tarzan@enron.com',      # 5: Not in predictions
+            'jane@enron.com',        # 6: Not in predictions
+            'christophe@enron.com',  # 7: Not in predictions
+            'kevin@enron.com',       # 8: Not in predictions
+            'brian@enron.com',       # 9: Not in predictions
+            'nigel@enron.com'        # 10: Not in predictions
+        ]
+        self.assertAveragePrecisionEquals(true_recipients, 0.23)
+
+    def test_avg_precision_complex_score_length_eleven(self):
+        true_recipients = [
+            'ben@enron.com',         # 1: In predictions
+            'michelle@enron.com',    # 2: Not in predictions
+            'jack@enron.com',        # 3: In predictions
+            'sophie@enron.com',      # 4: Not in predictions
+            'tarzan@enron.com',      # 5: Not in predictions
+            'jane@enron.com',        # 6: Not in predictions
+            'christophe@enron.com',  # 7: Not in predictions
+            'kevin@enron.com',       # 8: Not in predictions
+            'brian@enron.com',       # 9: Not in predictions
+            'nigel@enron.com',       # 10: Not in predictions
+            'milie@enron.com'        # 11: Not in predictions
+        ]
+        self.assertAveragePrecisionEquals(true_recipients, 0.23)
+
+
+class TestMeanAveragePrecisionAt10(unittest.TestCase):
+
+    def setUp(self):
+        self.recipients_predictions = [
+            [
+                'jack@enron.com',
+                'ben@enron.com',
+                'maria@enron.com',
+                'peter@enron.com',
+                'christian@enron.com',
+                'marc@enron.com',
+                'hugues@enron.com',
+                'nathan@enron.com',
+                'robin@enron.com',
+                'sophie@enron.com',
+            ],
+            [
+                'jack@enron.com',
+                'ben@enron.com',
+                'maria@enron.com',
+                'peter@enron.com',
+                'christian@enron.com',
+                'marc@enron.com',
+                'hugues@enron.com',
+                'nathan@enron.com',
+                'robin@enron.com',
+                'sophie@enron.com',
+            ]
+        ]
+
+    def assertMeanAveragePrecisionEquals(self, true_recipients, p):
+        self.assertEqual(
+            metrics.mean_average_precision(
+                recipients_predictions=self.recipients_predictions,
+                true_recipients_list=true_recipients
+            ), p
+        )
+
+    def test_mean_avg_precision_complex_score_length_ten(self):
+        true_recipients_list = [
+            [
+                'ben@enron.com',         # 1: In predictions
+                'michelle@enron.com',    # 2: Not in predictions
+                'jack@enron.com',        # 3: In predictions
+                'sophie@enron.com',      # 4: Not in predictions
+                'tarzan@enron.com',      # 5: Not in predictions
+                'jane@enron.com',        # 6: Not in predictions
+                'christophe@enron.com',  # 7: Not in predictions
+                'kevin@enron.com',       # 8: Not in predictions
+                'brian@enron.com',       # 9: Not in predictions
+                'nigel@enron.com'        # 10: Not in predictions
+            ],
+            [
+                'jack@enron.com',        # 1: In predictions
+                'ben@enron.com',         # 2: In predictions
+                'maria@enron.com',       # 3: In predictions
+                'peter@enron.com',       # 4: In predictions
+                'christian@enron.com',   # 5: In predictions
+                'marc@enron.com',        # 6: In predictions
+                'hugues@enron.com',      # 7: In predictions
+                'nathan@enron.com',      # 8: In predictions
+                'robin@enron.com',       # 9: In predictions
+                'sophie@enron.com',      # 10: In predictions
+            ]
+        ]
+        self.assertMeanAveragePrecisionEquals(true_recipients_list, (0.23 + 1) / 2)
+
+    def test_mean_avg_precision_can_be_used_as_avg_precision(self):
+        self.recipients_predictions = [
+            'jack@enron.com',
+            'ben@enron.com',
+            'maria@enron.com',
+            'peter@enron.com',
+            'christian@enron.com',
+            'marc@enron.com',
+            'hugues@enron.com',
+            'nathan@enron.com',
+            'robin@enron.com',
+            'sophie@enron.com',
+        ]
+
+        true_recipients_list = [
+            'ben@enron.com',         # 1: In predictions
+            'michelle@enron.com',    # 2: Not in predictions
+            'jack@enron.com',        # 3: In predictions
+            'sophie@enron.com',      # 4: Not in predictions
+            'tarzan@enron.com',      # 5: Not in predictions
+            'jane@enron.com',        # 6: Not in predictions
+            'christophe@enron.com',  # 7: Not in predictions
+            'kevin@enron.com',       # 8: Not in predictions
+            'brian@enron.com',       # 9: Not in predictions
+            'nigel@enron.com'        # 10: Not in predictions
+        ]
+
+        with warnings.catch_warnings(record=True) as warning:
+            self.assertMeanAveragePrecisionEquals(
+                true_recipients_list,
+                metrics.average_precision(self.recipients_predictions, true_recipients_list)
+            )
+            self.assertTrue(len(warning) == 1)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
These functions are essential to evaluate our model. They use precision
at ten as defined in Kaggle challenge evaluation

You can use them with

    >>> from model_evaluation import metrics
    >>> # Define recipients_prediction and true_recipients
    >>> ...
    >>> metrics.average_precision(recipients_prediction, true_recipients)
    0.26
    >>> # Define recipients_predictions and true_recipients_list
    >>> ...
    >>> metrics.mean_average_precision(recipients_predictions, true_recipients_list)
    0.37